### PR TITLE
bug fix: choose system-specific pathSeparator

### DIFF
--- a/lib/page/weight_manager.dart
+++ b/lib/page/weight_manager.dart
@@ -470,7 +470,7 @@ class _CustomDirectoryTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final customDir = ref.watch(P.preference.customModelsDir);
     final documentsDir = ref.watch(P.app.effectiveDocumentsDir)?.path;
-    final defaultDir = documentsDir != null ? "$documentsDir/${Config.modelsDirName}" : "";
+    final defaultDir = documentsDir != null ? documentsDir + Platform.pathSeparator + Config.modelsDirName : "";
     final s = S.of(context);
 
     final finalDirString = customDir ?? defaultDir;


### PR DESCRIPTION
Original situation:
<img width="411" height="46" alt="image" src="https://github.com/user-attachments/assets/c919aba6-3278-4f1d-a4f9-3aa566de2603" />

after fixing:
<img width="406" height="36" alt="image" src="https://github.com/user-attachments/assets/dd3c693a-e3cf-4aa3-8b8f-484727f1d24d" />
