### PR TITLE
chore: switch translator page to static material symbols import

### DIFF
--- a/lib/page/translator.dart
+++ b/lib/page/translator.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:halo/halo.dart';
 import 'package:halo_state/halo_state.dart';
-import 'package:material_symbols_icons/material_symbols_icons.dart';
+import 'package:material_symbols_icons/symbols.dart';
 
 // Project imports:
 import 'package:zone/gen/l10n.dart';


### PR DESCRIPTION
### Motivation
- Align `lib/page/translator.dart` with project icon import constraints by replacing the broad `material_symbols_icons/material_symbols_icons.dart` import with the static `material_symbols_icons/symbols.dart` import to keep icon usage explicit and tree-shake friendly

### Description
- Replaced `import 'package:material_symbols_icons/material_symbols_icons.dart';` with `import 'package:material_symbols_icons/symbols.dart';` in `lib/page/translator.dart` as a single-line, low-risk change

### Testing
- Ran repository search `rg` for disallowed imports (`material_symbols_icons/material_symbols_icons.dart`, `material_symbols_icons/get.dart`, `material_symbols_icons/symbols_map.dart`) and found no remaining matches, success
- Performed `git commit` for the change and the commit succeeded, success
- Attempted `flutter --version` and `dart --version` in the environment but both commands were not available (`command not found`), so build-time checks could not be executed, failure

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00a7a68208324816e0aa7f229dde5)