### PR TITLE
fix(windows-update): preserve repeated distribution keys when requesting latest downloads

### DIFF
--- a/lib/store/app.dart
+++ b/lib/store/app.dart
@@ -835,8 +835,7 @@ extension _$App on _App {
     // 构建查询参数，使用 List 来支持多个相同的 key
     // NestJS 的 @Query('key') 可以接受数组，格式为 ?key=value1&key=value2
     final queryParts = keys.map((key) => 'key=${Uri.encodeComponent(key)}').toList();
-    String queryString = queryParts.join('&');
-    queryString = Uri.encodeComponent(queryString);
+    final queryString = queryParts.join('&');
 
     // 构建完整的 URL，包含查询参数
     final baseUrl = "${Config.domain}/distributions/latest";


### PR DESCRIPTION
## Summary
This fixes the app update request used by desktop clients when querying `/distributions/latest`.

The app currently percent-encodes the entire repeated `key=` query string, so instead of sending:

`/distributions/latest?key=winZipGR&key=winHF&key=winAF&key=winGR...`

it sends:

`/distributions/latest?key%3DwinZipGR%26key%3DwinHF%26key%3DwinAF%26key%3DwinGR...`

Because of that, the backend does not receive any `key` filters and returns all platform distributions.
The client then picks the highest-build `*GR` asset from the full response, which can incorrectly resolve to Android APKs on Windows.

## Root Cause
In `lib/store/app.dart`, `_getLatestVersionInfo()` encodes each key correctly, but then encodes the full joined query string a second time:

```dart
final queryParts = keys.map((key) => 'key=${Uri.encodeComponent(key)}').toList();
String queryString = queryParts.join('&');
queryString = Uri.encodeComponent(queryString);
```

That second `Uri.encodeComponent(queryString)` is the bug.

## Expected vs Actual
### If Apple made this mistake, what would we expect?
A macOS client should request only macOS distribution keys, receive only macOS assets, and when a direct installer is available, open that installer directly. If no direct installer is available, it should fall back to the official download website.

### What actually happens when this bug exists?
The malformed request drops the platform filter. The backend responds with assets for every platform. The client then selects a highest-build GitHub Release asset from that mixed list, so a Windows x64 user can be sent to the Android APK instead of a Windows installer or zip.

## Fix
Stop encoding the full joined query string. Keep only the per-key encoding:

```dart
final queryParts = keys.map((key) => 'key=${Uri.encodeComponent(key)}').toList();
final queryString = queryParts.join('&');
```

## User Impact
- Windows x64 update prompts will resolve to Windows assets again
- When a direct installer exists, the update action can open it directly
- If direct download cannot be resolved, the existing fallback to the official download page remains intact
