### PR TITLE
fix: pause completion auto-scroll while reading

### DIFF
--- a/lib/page/completion/_completion_controller.dart
+++ b/lib/page/completion/_completion_controller.dart
@@ -52,6 +52,7 @@ class CompletionController {
   }
 
   void init() {
+    CompletionState.startAutoScrolling();
     for (final arg in _decodeParam.keys) {
       _originDecodeParam[arg] = P.rwkvParams.arguments(arg).q;
       P.rwkvParams.arguments(arg).q = _decodeParam[arg]!;
@@ -130,6 +131,7 @@ class CompletionController {
       _node.tail.switched = false;
     }
 
+    CompletionState.startAutoScrolling();
     CompletionState.generating.q = true;
     CompletionState.generateButtonEnabled.q = false;
 

--- a/lib/page/completion/_completion_state.dart
+++ b/lib/page/completion/_completion_state.dart
@@ -29,6 +29,24 @@ class CompletionState {
   static final generatingItem = qs<CompletionItemNode?>(null);
 
   static bool autoScrolling = true;
+
+  static void startAutoScrolling() {
+    autoScrolling = true;
+  }
+
+  static bool onContentScrollNotification(ScrollNotification notification) {
+    if (notification.metrics.axis != Axis.vertical) return false;
+
+    if (notification is ScrollStartNotification && notification.dragDetails != null) {
+      autoScrolling = false;
+      return false;
+    }
+
+    if (notification is! ScrollEndNotification) return false;
+    if (notification.metrics.extentAfter > 1) return false;
+    autoScrolling = true;
+    return false;
+  }
 }
 
 class CompletionItemNode {

--- a/lib/page/completion/completion_page.dart
+++ b/lib/page/completion/completion_page.dart
@@ -225,45 +225,25 @@ class _Body extends StatelessWidget {
   }
 }
 
-class _ContentArea extends StatefulWidget {
+class _ContentArea extends StatelessWidget {
   const _ContentArea();
 
   @override
-  State<_ContentArea> createState() => _ContentAreaState();
+  Widget build(BuildContext context) {
+    return CompletionAutoScrollRegion(child: const _ContentList());
+  }
 }
 
-class _ContentAreaState extends State<_ContentArea> {
-  bool _resumeAutoScrolling = false;
+class CompletionAutoScrollRegion extends StatelessWidget {
+  final Widget child;
 
-  void _onPointerDown(PointerDownEvent event) {
-    if (!CompletionState.autoScrolling) {
-      _resumeAutoScrolling = false;
-      return;
-    }
-
-    CompletionState.autoScrolling = false;
-    _resumeAutoScrolling = true;
-  }
-
-  void _onPointerUp(PointerUpEvent event) {
-    if (!_resumeAutoScrolling) {
-      return;
-    }
-
-    Future.delayed(const Duration(milliseconds: 1000), () {
-      if (!mounted) {
-        return;
-      }
-      CompletionState.autoScrolling = true;
-    });
-  }
+  const CompletionAutoScrollRegion({required this.child, super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Listener(
-      onPointerDown: _onPointerDown,
-      onPointerUp: _onPointerUp,
-      child: const _ContentList(),
+    return NotificationListener<ScrollNotification>(
+      onNotification: CompletionState.onContentScrollNotification,
+      child: child,
     );
   }
 }

--- a/test/completion_auto_scroll_test.dart
+++ b/test/completion_auto_scroll_test.dart
@@ -1,0 +1,53 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
+import 'package:zone/page/completion/_completion_state.dart';
+import 'package:zone/page/completion/completion_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(CompletionState.startAutoScrolling);
+
+  testWidgets('manual scrolling pauses auto scroll until returning to the bottom', (tester) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 240,
+            child: CompletionAutoScrollRegion(
+              child: ListView.builder(
+                controller: controller,
+                itemCount: 50,
+                itemExtent: 40,
+                itemBuilder: (context, index) => Text('Line $index'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(CompletionState.autoScrolling, isTrue);
+
+    await tester.drag(find.byType(ListView), const Offset(0, -120));
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, greaterThan(0));
+    expect(controller.offset, lessThan(controller.position.maxScrollExtent));
+    expect(CompletionState.autoScrolling, isFalse);
+
+    await tester.pump(const Duration(seconds: 2));
+    expect(CompletionState.autoScrolling, isFalse);
+
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await tester.pumpAndSettle();
+
+    expect(CompletionState.autoScrolling, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

- pause completion auto-scroll when the user starts scrolling
- keep the reading position stable until the user returns to the bottom or starts a new generation
- add a widget regression test for the interaction

## Verification

- `flutter test test/completion_auto_scroll_test.dart`
- `flutter analyze lib/page/completion/_completion_state.dart lib/page/completion/_completion_controller.dart lib/page/completion/completion_page.dart test/completion_auto_scroll_test.dart`
- `dart run tools/bin/agent_check.dart --rules-only`

Fixes #75