### PR TITLE
build(windows): Add compile definition to suppress deprecation warnings for experimental coroutines

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -10,6 +10,8 @@ set(BINARY_NAME "RWKV_Chat")
 # versions of CMake.
 cmake_policy(VERSION 3.14...3.25)
 
+add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Define build configuration option.
 get_property(IS_MULTICONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(IS_MULTICONFIG)


### PR DESCRIPTION
Add the macro definition _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS to eliminate deprecation warnings of experimental coroutines during Windows builds.